### PR TITLE
libgdal 2.2.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: b87cc7e70eeb10091890c9cb8e07a8f7f5e1a358473dea40dc272da252e4aa25
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
   rpaths:
     - lib/R/lib/
@@ -25,18 +25,12 @@ requirements:
     - posix  # [win]
     - m2w64-toolchain  # [win]
     - gcc  # [not win]
-    - libgdal 2.1.*
-    # This is a hacky and flaky to workaround #2.
-    # If defaults ever compile thier ligdal with the same icu this solutions is broken!!!
-    - icu 58.1
+    - libgdal 2.2.*
   run:
     - r-base
     - r-sp
     - libgcc  # [not win]
-    - libgdal 2.1.*
-    # This is a hacky and flaky to workaround #2.
-    # If defaults ever compile thier ligdal with the same icu this solutions is broken!!!
-    - icu 58.1
+    - libgdal 2.2.*
 
 test:
   commands:


### PR DESCRIPTION
@daf this is another attempt to workaround conda's solver bugs. You can create an env with,

```
conda create -n TEST r-rgdal libgdal=2.2
```

and this will work as long as `defaults` does not add `libgdal 2.2.*`. However, this comes with a caveat! You won't be able to install many packages from conda-forge that depends on `libgdal 2.1`, like `fiona` and `rasterio`, alongside `r-rgdal` .