### PR TITLE
pin gdal 2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: b87cc7e70eeb10091890c9cb8e07a8f7f5e1a358473dea40dc272da252e4aa25
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
   rpaths:
     - lib/R/lib/
@@ -25,12 +25,12 @@ requirements:
     - posix  # [win]
     - m2w64-toolchain  # [win]
     - gcc  # [not win]
-    - libgdal 2.2.*
+    - libgdal 2.1.*
   run:
     - r-base
     - r-sp
     - libgcc  # [not win]
-    - libgdal 2.2.*
+    - libgdal 2.1.*
 
 test:
   commands:


### PR DESCRIPTION
This won't work b/c the channel preference feature is unreliable when it comes to `r` packages. Right now it is fetching `icu 58.2` and `libkml 1.3.0` from `defaults`. The former will be "fixed" by https://github.com/conda-forge/icu-feedstock/pull/17. But the latter is unclear to me how we would fix it b/c the `libkml` version the same, the difference is the version and naming of `boost 1.64.*` (conda-forge) vs `libboost 1.65.1` (defaults).

Ping @msarahan here for an advice on what would be a way to solve the boost naming.

See the current solver solution with the issue I mentioned above:

```
The following NEW packages will be INSTALLED:

    bzip2:           1.0.6-1           conda-forge
    ca-certificates: 2017.7.27.1-0     conda-forge
    cairo:           1.14.6-5          conda-forge
    cloog:           0.18.0-0          defaults   
    curl:            7.55.1-0          conda-forge
    expat:           2.1.0-3           conda-forge
    fontconfig:      2.12.1-5          conda-forge
    freetype:        2.7-2             conda-forge
    freexl:          1.0.2-2           conda-forge
    gcc:             4.8.5-7           defaults   
    geos:            3.6.2-1           conda-forge
    gettext:         0.19.7-1          conda-forge
    giflib:          5.1.4-0           conda-forge
    glib:            2.51.4-0          conda-forge
    gmp:             6.1.2-0           conda-forge
    graphite2:       1.3.9-0           conda-forge
    gsl:             2.1-2             conda-forge
    harfbuzz:        1.4.3-0           conda-forge
    hdf4:            4.2.13-0          conda-forge
    hdf5:            1.10.1-1          conda-forge
    icu:             58.2-h211956c_0   defaults   
    isl:             0.12.2-0          defaults   
    jpeg:            9b-2              conda-forge
    json-c:          0.12.1-0          conda-forge
    kealib:          1.4.7-4           conda-forge
    krb5:            1.14.2-0          conda-forge
    libboost:        1.65.1-h4055789_3 defaults   
    libdap4:         3.18.3-2          conda-forge
    libffi:          3.2.1-3           conda-forge
    libgcc:          7.2.0-h69d50b8_2  defaults   
    libgcc-ng:       7.2.0-h7cc24e2_2  defaults   
    libgdal:         2.1.4-5           conda-forge
    libgfortran:     3.0.0-1           defaults   
    libiconv:        1.14-4            conda-forge
    libkml:          1.3.0-h8777076_2  defaults   
    libnetcdf:       4.4.1.1-10        conda-forge
    libpng:          1.6.28-2          conda-forge
    libpq:           9.6.3-0           conda-forge
    libspatialite:   4.3.0a-17         conda-forge
    libssh2:         1.8.0-2           conda-forge
    libstdcxx-ng:    7.2.0-h7a57d05_2  defaults   
    libtiff:         4.0.7-1           conda-forge
    libxml2:         2.9.5-1           conda-forge
    mpc:             1.0.3-4           conda-forge
    mpfr:            3.1.5-0           conda-forge
    ncurses:         5.9-10            conda-forge
    openjpeg:        2.1.2-3           conda-forge
    openssl:         1.0.2l-0          conda-forge
    pango:           1.40.4-0          conda-forge
    pcre:            8.39-0            conda-forge
    pixman:          0.34.0-0          conda-forge
    poppler:         0.52.0-3          conda-forge
    poppler-data:    0.4.7-0           conda-forge
    proj4:           4.9.3-5           conda-forge
    r-base:          3.4.1-1           conda-forge
    r-lattice:       0.20_34-r3.4.1_0  conda-forge
    r-sp:            1.2_4-r3.4.1_0    conda-forge
    readline:        6.2-0             conda-forge
    sqlite:          3.13.0-1          conda-forge
    tk:              8.5.19-2          conda-forge
    util-linux:      2.21-0            defaults   
    xerces-c:        3.1.4-3           conda-forge
    xz:              5.2.3-0           conda-forge
    zlib:            1.2.11-0          conda-forge
```