### PR TITLE
Update to 1.2 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,6 @@
 version: 2
 
 jobs:
-  build__CONDA_R_3.3.2:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_R: "3.3.2"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_R=${CONDA_R}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
   build__CONDA_R_3.4.1:
     working_directory: ~/test
     machine: true
@@ -48,5 +27,4 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build__CONDA_R_3.3.2
       - build__CONDA_R_3.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_R=3.3.2
     - CONDA_R=3.4.1
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '1.2-8' %}
+{% set version = '1.2-16' %}
 
 package:
   name: r-rgdal
@@ -9,10 +9,10 @@ source:
   url:
     - https://cran.r-project.org/src/contrib/rgdal_{{ version }}.tar.gz
     - https://cran.r-project.org/src/contrib/Archive/rgdal/rgdal_{{ version }}.tar.gz
-  sha256: b87cc7e70eeb10091890c9cb8e07a8f7f5e1a358473dea40dc272da252e4aa25
+  sha256: 017fefea4f9a6d4540d128c707197b7025b55e4aff98fc763065366b025b03c9
 
 build:
-  number: 3
+  number: 0
   skip: True  # [win]
   rpaths:
     - lib/R/lib/
@@ -21,16 +21,16 @@ build:
 requirements:
   build:
     - r-base
-    - r-sp
+    - r-sp >=1.1_0
     - posix  # [win]
     - m2w64-toolchain  # [win]
     - gcc  # [not win]
-    - libgdal 2.1.*
+    - libgdal 2.2.*
   run:
     - r-base
-    - r-sp
+    - r-sp >=1.1_0
     - libgcc  # [not win]
-    - libgdal 2.1.*
+    - libgdal 2.2.*
 
 test:
   commands:


### PR DESCRIPTION
This won't support `R 3.3.2` b/c of the outdated pinning. I don't have time to fix `R` and I do believe we should move to `R >=3.4.1`.